### PR TITLE
Rescue JSON::ParserError

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -26,6 +26,8 @@ class CompareLinker
         github_url = redirect_url(github_url)
         _, @repo_owner, @repo_name = github_url.match(%r!github\.com/([^/]+)/([^/]+)!).to_a
       end
+    rescue JSON::ParserError
+      @homepage_uri = "https://rubygems.org/gems/#{gem_name}"
     end
 
     def repo_full_name

--- a/spec/fixtures/not_found.json
+++ b/spec/fixtures/not_found.json
@@ -1,0 +1,1 @@
+This rubygem could not be found.

--- a/spec/lib/compare_linker/github_link_finder_spec.rb
+++ b/spec/lib/compare_linker/github_link_finder_spec.rb
@@ -28,5 +28,16 @@ describe CompareLinker::GithubLinkFinder do
         expect(subject.repo_name).to eq "webtranslateit"
       end
     end
+
+    context "if gem not found on rubygems.org" do
+      before do
+        allow(HTTPClient).to receive_message_chain(:get, :body).and_return load_fixture("not_found.json")
+      end
+
+      it "extracts homepage_uri" do
+        subject.find("not_found")
+        expect(subject.homepage_uri).to eq("https://rubygems.org/gems/not_found")
+      end
+    end
   end
 end


### PR DESCRIPTION
recover of `unexpected token at 'This rubygem could not be found.' (JSON::ParserError)`.