### PR TITLE
Add workaround which Location Header isnot absoluteURI

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -39,15 +39,22 @@ class CompareLinker
 
     def redirect_url(url, limit = 5)
       raise ArgumentError, 'HTTP redirect too deep' if limit <= 0
-      response = Net::HTTP.get_response(URI.parse(url))
+      uri = URI.parse(url)
+      response = Net::HTTP.get_response(uri)
       case response
       when Net::HTTPSuccess
         url
       when Net::HTTPRedirection
-        redirect_url(response['location'], limit - 1)
+        redirect_url(to_absolute(response['location'], uri), limit - 1)
       else
         raise ItemNotFound
       end
+    end
+
+    def to_absolute(location, uri)
+      return location if location =~ /\Ahttp/
+      # RFC2394 violation?
+      "#{uri.scheme}://#{uri.host}#{location}"
     end
   end
 end

--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -47,7 +47,7 @@ class CompareLinker
       when Net::HTTPRedirection
         redirect_url(to_absolute(response['location'], uri), limit - 1)
       else
-        raise ItemNotFound
+        raise 'item not found'
       end
     end
 


### PR DESCRIPTION
http://github.com/opscode/chef/ returns the following header.

```
HTTP/1.1 302 Found
Connection: close
Pragma: no-cache
cache-control: no-cache
Location: /TXQcK/opscode/chef/
```

I believe Location fieald must be absoluteURI for RFC2396. However I add the workaround.
