### PR TITLE
Fix item not found

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -20,11 +20,10 @@ class CompareLinker
         gem_info["source_code_uri"]
       ].find { |uri| uri.to_s.match(/github\.com\//) }
 
-      if github_url.nil?
-        @homepage_uri = gem_info["homepage_uri"]
-      else
-        github_url = redirect_url(github_url)
+      if github_url = redirect_url(github_url)
         _, @repo_owner, @repo_name = github_url.match(%r!github\.com/([^/]+)/([^/]+)!).to_a
+      else
+        @homepage_uri = gem_info["homepage_uri"]
       end
 
     rescue JSON::ParserError
@@ -38,7 +37,8 @@ class CompareLinker
     private
 
     def redirect_url(url, limit = 5)
-      raise ArgumentError, 'HTTP redirect too deep' if limit <= 0
+      return nil if url.nil?
+      return nil if limit <= 0
 
       uri = URI.parse(url)
       response = Net::HTTP.get_response(uri)
@@ -49,7 +49,7 @@ class CompareLinker
       when Net::HTTPRedirection
         redirect_url(to_absolute(response['location'], uri), limit - 1)
       else
-        raise 'item not found'
+        nil
       end
     end
 


### PR DESCRIPTION
Hi,
Thanks for circleci-bundle-update-pr & compare_linker :)

Today,
`"coffee-script-source (http://jashkenas.github.com/coffee-script/): 1.9.1 => 1.9.1.1"`
causes this error:

```
 * [new branch]      bundle-update-20150413 -> bundle-update-20150413
/home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker/github_link_finder.rb:52:in `redirect_url': item not found (RuntimeError)
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker/github_link_finder.rb:50:in `redirect_url'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker/github_link_finder.rb:26:in `find'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker.rb:34:in `block in make_compare_links'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker.rb:31:in `each'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker.rb:31:in `map'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/compare_linker-1.1.7/lib/compare_linker.rb:31:in `make_compare_links'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/circleci-bundle-update-pr-1.0.3/lib/circleci/bundle/update/pr.rb:53:in `add_comment_of_compare_linker'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/circleci-bundle-update-pr-1.0.3/lib/circleci/bundle/update/pr.rb:19:in `create_if_needed'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/gems/circleci-bundle-update-pr-1.0.3/bin/circleci-bundle-update-pr:5:in `<top (required)>'
	from /home/ubuntu/esa/vendor/bundle/ruby/2.2.0/bin/circleci-bundle-update-pr:23:in `load'
```
