### PR TITLE
Fix not found error for gems on rails-assets.org

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -27,7 +27,7 @@ class CompareLinker
         _, @repo_owner, @repo_name = github_url.match(%r!github\.com/([^/]+)/([^/]+)!).to_a
       end
 
-    rescue JSON::ParserError
+    rescue HTTPClient::BadResponseError, JSON::ParserError
       @homepage_uri = "https://rubygems.org/gems/#{gem_name}"
     end
 


### PR DESCRIPTION
```
HTTPClient::BadResponseError: unexpected response: #<HTTP::Message::Headers:0x007faa9f6f9518 @http_version="1.1", @body_size=0, @chunked=false, @request_method="GET", @request_uri=#<Addressable::URI:0x3fd54fb7d068 URI:https://rubygems.org/api/v1/gems/rails-assets-momentjs.json>, @request_query=nil, @request_absolute_uri=nil, @status_code=404, @reason_phrase="Not Found", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=#<Encoding:UTF-8>, @is_request=false, @header_item=[["Server", "nginx"], ["Date", "Mon, 13 Apr 2015 05:43:49 GMT"], ["Content-Type", "application/json; charset=utf-8"], ["Transfer-Encoding", "chunked"], ["Connection", "keep-alive"], ["Status", "404 Not Found"], ["X-Frame-Options", "SAMEORIGIN"], ["X-XSS-Protection", "1; mode=block"], ["X-Content-Type-Options", "nosniff"], ["Cache-Control", "no-cache"], ["X-Request-Id", "a2537272-e0ef-4b7d-ba92-6a93668f13e2"], ["X-Runtime", "0.003590"]], @dumped=false>
from /Users/fukayatsu/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/httpclient-2.6.0.1/lib/httpclient.rb:1076:in `success_content'
```