### PR TITLE
[WIP] Improve github compare link

### DIFF
--- a/lib/compare_linker/formatter/markdown.rb
+++ b/lib/compare_linker/formatter/markdown.rb
@@ -5,22 +5,25 @@ class CompareLinker
     class Markdown < Base
       def format(gem_info)
         g = OpenStruct.new(gem_info)
+        downgraded = downgrade?(g.old_ver, g.new_ver, g.old_tag, g.new_tag)
 
         text = "* [ ] "
         text += case
         when g.owner && g.old_rev && g.new_rev
-          "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_rev}...#{g.new_rev}"
+          range = downgraded ? "#{g.new_rev}...#{g.old_rev}" : "#{g.old_rev}...#{g.new_rev}"
+          "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{range}"
         when g.homepage_uri
           "[#{g.gem_name}](#{g.homepage_uri}): #{g.old_ver} => #{g.new_ver}"
         when g.old_tag && g.new_tag
-          "#{g.gem_name}: https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{g.old_tag}...#{g.new_tag}"
+          range = downgraded ? "#{g.new_tag}...#{g.old_tag}" : "#{g.old_tag}...#{g.new_tag}"
+          "#{g.gem_name}: https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{range}"
         when g.repo_owner && g.repo_name
           "[#{g.gem_name}](https://github.com/#{g.repo_owner}/#{g.repo_name}): #{g.old_ver} => #{g.new_ver}"
         else
           "#{g.gem_name}: (link not found) #{g.old_ver} => #{g.new_ver}"
         end
 
-        if downgrade?(g.old_ver, g.new_ver, g.old_tag, g.new_tag)
+        if downgraded
           text += " (downgrade)"
         end
 

--- a/lib/compare_linker/formatter/text.rb
+++ b/lib/compare_linker/formatter/text.rb
@@ -5,21 +5,24 @@ class CompareLinker
     class Text < Base
       def format(gem_info)
         g = OpenStruct.new(gem_info)
+        downgraded = downgrade?(g.old_ver, g.new_ver, g.old_tag, g.new_tag)
 
         text = case
         when g.owner && g.old_rev && g.new_rev
-          "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_rev}...#{g.new_rev}"
+          range = downgraded ? "#{g.new_rev}...#{g.old_rev}" : "#{g.old_rev}...#{g.new_rev}"
+          "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{range}"
         when g.homepage_uri
           "#{g.gem_name} (#{g.homepage_uri}): #{g.old_ver} => #{g.new_ver}"
         when g.old_tag && g.new_tag
-          "#{g.gem_name}: https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{g.old_tag}...#{g.new_tag}"
+          range = downgraded ? "#{g.new_tag}...#{g.old_tag}" : "#{g.old_tag}...#{g.new_tag}"
+          "#{g.gem_name}: https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{range}"
         when g.repo_owner && g.repo_name
           "#{g.gem_name}: https://github.com/#{g.repo_owner}/#{g.repo_name} #{g.old_ver} => #{g.new_ver}"
         else
           "#{g.gem_name} (link not found): #{g.old_ver} => #{g.new_ver}"
         end
 
-        if downgrade?(g.old_ver, g.new_ver, g.old_tag, g.new_tag)
+        if downgraded
           text += " (downgrade)"
         end
 


### PR DESCRIPTION
> * [ ] reek: https://github.com/troessner/reek/compare/v4.0.1...v3.11 (downgrade)

というようなlinkの場合、遷移先で

> v4.0.1 is up to date with all commits from v3.11. Try switching the base for your comparison.

という表示になってしまうのを修正する試みです。

とはいえ、`switching the base` のところをクリックすればいいだけなので現状のままでもいいかも。

TODO

- [ ] Add spec