### PR TITLE
Rescue missing GitHub compare links

### DIFF
--- a/data/rubygems.yml
+++ b/data/rubygems.yml
@@ -1,0 +1,3 @@
+# Gem name: GitHub repository
+
+capistrano: capistrano/capistrano

--- a/data/rubygems.yml
+++ b/data/rubygems.yml
@@ -1,3 +1,13 @@
 # Gem name: GitHub repository
 
+actioncable: rails/rails
+actionmailer: rails/rails
+actionpack: rails/rails
+actionview: rails/rails
+activejob: rails/rails
+activemodel: rails/rails
+activerecord: rails/rails
+activesupport: rails/rails
 capistrano: capistrano/capistrano
+railties: rails/rails
+serverspec: mizzy/serverspec

--- a/lib/compare_linker.rb
+++ b/lib/compare_linker.rb
@@ -41,9 +41,9 @@ class CompareLinker
             gem_info[:repo_owner] = finder.repo_owner
             gem_info[:repo_name] = finder.repo_name
 
-            tag_finder = GithubTagFinder.new(octokit)
-            old_tag = tag_finder.find(finder.repo_full_name, gem_info[:old_ver])
-            new_tag = tag_finder.find(finder.repo_full_name, gem_info[:new_ver])
+            tag_finder = GithubTagFinder.new(octokit, gem_name, finder.repo_full_name)
+            old_tag = tag_finder.find(gem_info[:old_ver])
+            new_tag = tag_finder.find(gem_info[:new_ver])
 
             if old_tag && new_tag
               gem_info[:old_tag] = old_tag.name

--- a/lib/compare_linker.rb
+++ b/lib/compare_linker.rb
@@ -2,19 +2,21 @@ require "octokit"
 require_relative "compare_linker/formatter/base"
 require_relative "compare_linker/formatter/text"
 require_relative "compare_linker/formatter/markdown"
+require_relative "compare_linker/gem_dictionary"
 require_relative "compare_linker/github_link_finder"
 require_relative "compare_linker/github_tag_finder"
 require_relative "compare_linker/lockfile_comparator"
 require_relative "compare_linker/lockfile_fetcher"
 
 class CompareLinker
-  attr_reader :repo_full_name, :pr_number, :compare_links
+  attr_reader :repo_full_name, :pr_number, :compare_links, :gem_dictionary
   attr_accessor :formatter, :octokit
 
   def initialize(repo_full_name, pr_number)
     @repo_full_name = repo_full_name
     @pr_number = pr_number
     @octokit ||= Octokit::Client.new(access_token: ENV["OCTOKIT_ACCESS_TOKEN"])
+    @gem_dictionary = GemDictionary.new
     @formatter = Formatter::Text.new
   end
 
@@ -30,10 +32,10 @@ class CompareLinker
       comparator.compare(old_lockfile, new_lockfile)
       @compare_links = comparator.updated_gems.map { |gem_name, gem_info|
         if gem_info[:owner].nil?
-          finder = GithubLinkFinder.new(octokit)
+          finder = GithubLinkFinder.new(octokit, gem_dictionary)
           finder.find(gem_name)
+          gem_info[:homepage_uri] = finder.homepage_uri
           if finder.repo_owner.nil?
-            gem_info[:homepage_uri] = finder.homepage_uri
             formatter.format(gem_info)
           else
             gem_info[:repo_owner] = finder.repo_owner

--- a/lib/compare_linker/formatter/base.rb
+++ b/lib/compare_linker/formatter/base.rb
@@ -9,7 +9,7 @@ class CompareLinker
       end
 
       def to_ver(tag)
-        tag.sub(/\Av/, '')
+        return $1 if tag =~ /(\d+(?:\.\d+)+)\z/
       end
     end
   end

--- a/lib/compare_linker/formatter/markdown.rb
+++ b/lib/compare_linker/formatter/markdown.rb
@@ -10,6 +10,8 @@ class CompareLinker
         text += case
         when g.owner && g.old_rev && g.new_rev
           "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_rev}...#{g.new_rev}"
+        when g.homepage_uri && g.old_tag && g.new_tag
+          "[#{g.gem_name}](#{g.homepage_uri}): https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{g.old_tag}...#{g.new_tag}"
         when g.homepage_uri
           "[#{g.gem_name}](#{g.homepage_uri}): #{g.old_ver} => #{g.new_ver}"
         when g.old_tag && g.new_tag

--- a/lib/compare_linker/formatter/text.rb
+++ b/lib/compare_linker/formatter/text.rb
@@ -9,6 +9,8 @@ class CompareLinker
         text = case
         when g.owner && g.old_rev && g.new_rev
           "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_rev}...#{g.new_rev}"
+        when g.homepage_uri && g.old_tag && g.new_tag
+          "#{g.gem_name} (#{g.homepage_uri}): https://github.com/#{g.repo_owner}/#{g.repo_name}/compare/#{g.old_tag}...#{g.new_tag}"
         when g.homepage_uri
           "#{g.gem_name} (#{g.homepage_uri}): #{g.old_ver} => #{g.new_ver}"
         when g.old_tag && g.new_tag

--- a/lib/compare_linker/gem_dictionary.rb
+++ b/lib/compare_linker/gem_dictionary.rb
@@ -1,0 +1,32 @@
+require "yaml"
+
+class CompareLinker
+  class GemDictionary
+    attr_reader :file, :rubygems
+
+    def initialize
+      @file = File.join(__dir__, '../../data/rubygems.yml')
+    end
+
+    # Look gem info up from Dictionary
+    #
+    # @param gem_name [String]
+    # @return [Array<String>] [repo_owner, repo_name]
+    # @return [Array<NilClass>] cannot look up
+    def lookup(gem_name)
+      repo_full_name = rubygems[gem_name]
+
+      if repo_full_name
+        repo_full_name.split("/")
+      else
+        [nil, nil]
+      end
+    end
+
+    private
+
+    def rubygems
+      @rubygems ||= YAML.load(IO.read(file))
+    end
+  end
+end

--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -4,10 +4,11 @@ require "net/http"
 
 class CompareLinker
   class GithubLinkFinder
-    attr_reader :octokit, :repo_owner, :repo_name, :homepage_uri
+    attr_reader :octokit, :gem_dictionary, :repo_owner, :repo_name, :homepage_uri
 
-    def initialize(octokit)
+    def initialize(octokit, gem_dictionary)
       @octokit = octokit
+      @gem_dictionary = gem_dictionary
     end
 
     def find(gem_name)
@@ -23,6 +24,7 @@ class CompareLinker
       if github_url = redirect_url(github_url)
         _, @repo_owner, @repo_name = github_url.match(%r!github\.com/([^/]+)/([^/]+)!).to_a
       else
+        @repo_owner, @repo_name  = gem_dictionary.lookup(gem_info["name"])
         @homepage_uri = gem_info["homepage_uri"]
       end
 

--- a/lib/compare_linker/github_tag_finder.rb
+++ b/lib/compare_linker/github_tag_finder.rb
@@ -7,12 +7,22 @@ class CompareLinker
     end
 
     def find(repo_full_name, gem_version)
-      tags = octokit.tags(repo_full_name)
+      tags = auto_paginate { octokit.tags(repo_full_name) }
       if tags
         tags.find { |tag|
           tag.name == gem_version || tag.name == "v#{gem_version}"
         }
       end
+    end
+
+    private
+
+    def auto_paginate
+      original = octokit.auto_paginate
+      octokit.auto_paginate = true
+      yield
+    ensure
+      octokit.auto_paginate = original
     end
   end
 end

--- a/lib/compare_linker/github_tag_finder.rb
+++ b/lib/compare_linker/github_tag_finder.rb
@@ -1,16 +1,20 @@
 class CompareLinker
   class GithubTagFinder
-    attr_reader :octokit
+    attr_reader :octokit, :gem_name, :repo_full_name
 
-    def initialize(octokit)
+    def initialize(octokit, gem_name, repo_full_name)
       @octokit = octokit
+      @gem_name = gem_name
+      @repo_full_name = repo_full_name
     end
 
-    def find(repo_full_name, gem_version)
+    def find(gem_version)
       tags = auto_paginate { octokit.tags(repo_full_name) }
       if tags
         tags.find { |tag|
-          tag.name == gem_version || tag.name == "v#{gem_version}"
+          tag.name == gem_version ||
+            tag.name == "v#{gem_version}" ||
+            tag.name == "#{gem_name}-#{gem_version}"
         }
       end
     end

--- a/spec/lib/compare_linker/gem_dictionary_spec.rb
+++ b/spec/lib/compare_linker/gem_dictionary_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe CompareLinker::GemDictionary do
+  describe "#lookup" do
+    context 'given a gem name included in the dictionary' do
+      subject { described_class.new.lookup('serverspec') }
+      it { is_expected.to eq %w(mizzy serverspec) }
+    end
+
+    context 'given a gem name not included in the dictionary' do
+      subject { described_class.new.lookup('not_exist') }
+      it { is_expected.to eq [nil, nil] }
+    end
+  end
+end

--- a/spec/lib/compare_linker/github_link_finder_spec.rb
+++ b/spec/lib/compare_linker/github_link_finder_spec.rb
@@ -2,8 +2,9 @@ require "spec_helper"
 
 describe CompareLinker::GithubLinkFinder do
   let(:octokit) { double.as_null_object }
+  let(:gem_dictionary) { double.as_null_object }
 
-  subject { described_class.new(octokit) }
+  subject { described_class.new(octokit, gem_dictionary) }
 
 
   describe "#find" do


### PR DESCRIPTION
* Rescue gems that doesn't have GitHub URL
    * e.g. https://rubygems.org/gems/capistrano
* Rescue gems that has many tags
    * e.g. https://github.com/newrelic/rpm/tags
* Rescue gems that has tag names `<gem_name>-<version>`
    * https://github.com/djberg96/sys-proctable/tags