### PR TITLE
Add GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In addition to OCTOKIT_ACCESS_TOKEN, set the following environment variables.
 
 ```ruby
 ENV['ENTERPRISE_OCTOKIT_ACCESS_TOKEN'] = 'xxx'
-ENV['ENTERPRISE_OCTOKIT_HOST'] = 'www.example.com'
+ENV['ENTERPRISE_OCTOKIT_API_ENDPOINT'] = 'https://www.example.com/api/v3'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ comment = compare_linker.make_compare_links.to_a.join("\n")
 compare_linker.add_comment('masutaka/compare_linker', '17', comment)
 ```
 
+### GitHub Enterprise
+In addition to OCTOKIT_ACCESS_TOKEN, set the following environment variables.
+
+```ruby
+ENV['ENTERPRISE_OCTOKIT_ACCESS_TOKEN'] = 'xxx'
+ENV['ENTERPRISE_OCTOKIT_HOST'] = 'www.example.com'
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/compare_linker.rb
+++ b/lib/compare_linker.rb
@@ -10,21 +10,28 @@ require_relative "compare_linker/lockfile_fetcher"
 
 class CompareLinker
   attr_reader :repo_full_name, :pr_number, :compare_links, :gem_dictionary
-  attr_accessor :formatter, :octokit
+  attr_accessor :formatter, :octokit, :enterprise_octokit
 
   def initialize(repo_full_name, pr_number)
     @repo_full_name = repo_full_name
     @pr_number = pr_number
     @octokit ||= Octokit::Client.new(access_token: ENV["OCTOKIT_ACCESS_TOKEN"])
+    @enterprise_octokit =
+      if ENV["ENTERPRISE_OCTOKIT_ACCESS_TOKEN"] && ENV['ENTERPRISE_OCTOKIT_HOST']
+        Octokit::Client.new(access_token: ENV["ENTERPRISE_OCTOKIT_ACCESS_TOKEN"],
+                            api_endpoint: "https://#{ENV['ENTERPRISE_OCTOKIT_HOST']}/api/v3")
+      else
+        nil
+      end
     @gem_dictionary = GemDictionary.new
     @formatter = Formatter::Text.new
   end
 
   def make_compare_links
-    if octokit.pull_request_files(repo_full_name, pr_number).find { |resource| resource.filename == "Gemfile.lock" }
-      pull_request = octokit.pull_request(repo_full_name, pr_number)
+    if requested_repository_octokit.pull_request_files(repo_full_name, pr_number).find { |resource| resource.filename == "Gemfile.lock" }
+      pull_request = requested_repository_octokit.pull_request(repo_full_name, pr_number)
 
-      fetcher = LockfileFetcher.new(octokit)
+      fetcher = LockfileFetcher.new(requested_repository_octokit)
       old_lockfile = fetcher.fetch(repo_full_name, pull_request.base.sha)
       new_lockfile = fetcher.fetch(repo_full_name, pull_request.head.sha)
 
@@ -62,11 +69,17 @@ class CompareLinker
   end
 
   def add_comment(repo_full_name, pr_number, compare_links)
-    res = octokit.add_comment(
+    res = requested_repository_octokit.add_comment(
       repo_full_name,
       pr_number,
       compare_links
     )
-    "https://github.com/#{repo_full_name}/pull/#{pr_number}#issuecomment-#{res.id}"
+    res[:html_url]
+  end
+
+  private
+
+  def requested_repository_octokit
+    enterprise_octokit || octokit
   end
 end

--- a/lib/compare_linker.rb
+++ b/lib/compare_linker.rb
@@ -17,9 +17,9 @@ class CompareLinker
     @pr_number = pr_number
     @octokit ||= Octokit::Client.new(access_token: ENV["OCTOKIT_ACCESS_TOKEN"])
     @enterprise_octokit =
-      if ENV["ENTERPRISE_OCTOKIT_ACCESS_TOKEN"] && ENV['ENTERPRISE_OCTOKIT_HOST']
+      if ENV["ENTERPRISE_OCTOKIT_ACCESS_TOKEN"] && ENV['ENTERPRISE_OCTOKIT_API_ENDPOINT']
         Octokit::Client.new(access_token: ENV["ENTERPRISE_OCTOKIT_ACCESS_TOKEN"],
-                            api_endpoint: "https://#{ENV['ENTERPRISE_OCTOKIT_HOST']}/api/v3")
+                            api_endpoint: ENV["ENTERPRISE_OCTOKIT_API_ENDPOINT"])
       else
         nil
       end


### PR DESCRIPTION
## Summary
I added GitHub Enterprise support.
Because github enterprise has different access control, add enterprise_octokit.

It can also be used by setting ENTERPRISE_OCTOKIT_ACCESS_TOKEN and ENTERPRISE_OCTOKIT_HOST in environment variables.

## Testing
- I confirmed the operation with Github Enterprise I have contracted
- I confirmed that the original processing is not affected by normal Github