### PR TITLE
handle downgrade? error

### DIFF
--- a/lib/compare_linker/formatter/base.rb
+++ b/lib/compare_linker/formatter/base.rb
@@ -21,6 +21,8 @@ class CompareLinker
         Gem::Version.new(new_ver) < Gem::Version.new(old_ver) ||
           (old_tag && new_tag && Gem::Version.new(to_ver(new_tag)) < Gem::Version.new(to_ver(old_tag))) ||
           (old_rev && new_rev && Gem::Version.new(to_ver(new_rev)) < Gem::Version.new(to_ver(old_rev)))
+      rescue ArgumentError # Gem::Version raise ArgumentError if it is invalid as version
+        false
       end
 
       def to_ver(tag)


### PR DESCRIPTION
I got following error using https://github.com/walf443/compare_linker/tree/detect_argument_error branch

```
[test_compare_linker_fix 9c9d4a9] $ bundle update && bundle update --ruby
 1 file changed, 17 insertions(+), 17 deletions(-)
Traceback (most recent call last):
	10: from /usr/local/bundle/bin/circleci-bundle-update-pr:23:in `<main>'
	 9: from /usr/local/bundle/bin/circleci-bundle-update-pr:23:in `load'
	 8: from /usr/local/bundle/gems/circleci-bundle-update-pr-1.11.1/bin/circleci-bundle-update-pr:13:in `<top (required)>'
	 7: from /usr/local/bundle/gems/circleci-bundle-update-pr-1.11.1/lib/circleci/bundle/update/pr.rb:23:in `create_if_needed'
	 6: from /usr/local/bundle/gems/circleci-bundle-update-pr-1.11.1/lib/circleci/bundle/update/pr.rb:63:in `update_pull_request_body'
	 5: from /usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker.rb:31:in `make_compare_links'
	 4: from /usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker.rb:31:in `map'
	 3: from /usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker.rb:31:in `each'
	 2: from /usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker.rb:55:in `block in make_compare_links'
	 1: from /usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker/formatter/base.rb:10:in `format'
/usr/local/bundle/gems/compare_linker-1.4.0/lib/compare_linker/formatter/base.rb:15:in `rescue in format': invalid gem version: {:owner=>"sds", :gem_name=>"slim-lint", :old_rev=>"dc24a0900a4bd29209b812e9119f5bc6eb3eb649", :new_rev=>"111e56fa5f4f75c03ad4043023232f7e972100d8"} (CompareLinker::Formatter::InvalidGemVersionError)
```
It seems that Gem::Version raise ArgumentError 

```
Gem::Version.new("dc24a0900a4bd29209b812e9119f5bc6eb3eb649")
ArgumentError: Malformed version number string dc24a0900a4bd29209b812e9119f5bc6eb3eb649
        from /Users/yoshimin/.rbenv/versions/2.3.5/lib/ruby/site_ruby/2.3.0/rubygems/version.rb:208:in `initialize'
        from /Users/yoshimin/.rbenv/versions/2.3.5/lib/ruby/site_ruby/2.3.0/rubygems/version.rb:199:in `new'
        from /Users/yoshimin/.rbenv/versions/2.3.5/lib/ruby/site_ruby/2.3.0/rubygems/version.rb:199:in `new'
```
