### PR TITLE
Refactor: extract to make_compare_links_from_lockfiles

### DIFF
--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httpclient"
 
   spec.add_development_dependency "activesupport", "~> 4" # for ruby-2.[0-2].0 tests, required by factory_girl
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
# Context
I want to use `compare_linker` from outside GitHub (e.g. GitLab)

So I want to use following from my code.
https://github.com/masutaka/compare_linker/blob/v1.4.2/lib/compare_linker.rb#L29-L60

# Example
```ruby
gitlab = Gitlab.client
old_lockfile = gitlab.file_contents("my/project", "Gemfile.lock", "OLD_SHA1")
new_lockfile = gitlab.file_contents("my/project", "Gemfile.lock", "NEW_SHA1")

compare_linker = CompareLinker.new("dummy", "dummy")
compare_linker.make_compare_links_from_lockfiles(Bundler::LockfileParser.new(old_lockfile), Bundler::LockfileParser.new(new_lockfile))
```
