### PR TITLE
Fixed `uninitialized constant CompareLinker::LockfileFetcher::Base64 (NameError)`

### DIFF
--- a/lib/compare_linker/lockfile_fetcher.rb
+++ b/lib/compare_linker/lockfile_fetcher.rb
@@ -1,4 +1,5 @@
 require "bundler"
+require "base64"
 
 class CompareLinker
   class LockfileFetcher


### PR DESCRIPTION
I use [circleci-bundle-update-pr](https://github.com/masutaka/circleci-bundle-update-pr) on GitHub Actions

Suddenly the following error occurs and the body of the PullRequest is not generated 😢 

![image](https://github.com/masutaka/compare_linker/assets/608755/f3b8ce30-7b61-47fb-98f0-34ab86b81e9c)

Error log

```bash
+ circleci-bundle-update-pr CircleCI-bundle-updater xxxxxx@example.com --assignees sue445 main
To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses

(snip)

/opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems/compare_linker-1.4.4/lib/compare_linker/lockfile_fetcher.rb:18:in `fetch': uninitialized constant CompareLinker::LockfileFetcher::Base64 (NameError)
bundle-update-20240615040328 is created

        Base64.decode64(
        ^^^^^^
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems/compare_linker-1.4.4/lib/compare_linker.rb:26:in `make_compare_links'
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems/circleci-bundle-update-pr-5.0.3/lib/circleci/bundle/update/pr.rb:171:in `update_pull_request_body'
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems/circleci-bundle-update-pr-5.0.3/lib/circleci/bundle/update/pr.rb:35:in `create_if_needed'
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems/circleci-bundle-update-pr-5.0.3/bin/circleci-bundle-update-pr:15:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/bin/circleci-bundle-update-pr:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.2.4/x64/bin/circleci-bundle-update-pr:25:in `<main>'
```

It seems to me that it is recommended to `require "base64"` individually, as seen in the following

* https://docs.ruby-lang.org/ja/latest/method/Base64/m/decode64.html
* https://docs.ruby-lang.org/en/3.3/Base64.html

So I add `require "base64"`

It must have been working by accident until now... (maybe :sweat_smile:)

my patch is working on my repo

![image](https://github.com/masutaka/compare_linker/assets/608755/4013b611-e615-4b34-9ce7-2a729dde6583)

