### PR TITLE
Fix base64 warning

### DIFF
--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64"
   spec.add_dependency "octokit"
   spec.add_dependency "httpclient"
 

--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "base64"
-  spec.add_dependency "octokit"
   spec.add_dependency "httpclient"
+  spec.add_dependency "octokit"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "factory_bot"


### PR DESCRIPTION
🔗 https://github.com/masutaka/circleci-bundle-update-pr/pull/173#issuecomment-2205974289

> https://app.circleci.com/pipelines/github/masutaka/circleci-bundle-update-pr/414/workflows/acffdcc2-67f7-4e0d-bda8-fc691e47d28f/jobs/1803
>
>> /home/circleci/repo/vendor/bundle/ruby/3.3.0/gems/compare_linker-1.4.5/lib/compare_linker/lockfile_fetcher.rb:2: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of compare_linker-1.4.5 to add base64 into its gemspec.
>
> あとで直すか。

It's related to https://github.com/masutaka/compare_linker/pull/44
