### PR TITLE
Add workaround to factory_bot and activesupport dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-        cache-version: 1
     - name: Run rspec
       run: bundle exec rake spec
   pushover:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+        cache-version: 1
     - name: Run rspec
       run: bundle exec rake spec
   pushover:

--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httpclient"
   spec.add_dependency "octokit"
 
+  spec.add_development_dependency "activesupport", ">= 5.0.0", "< 7.2.0" # temporary pinned. See https://github.com/masutaka/compare_linker/pull/50
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The test failure occured in #49 test:

🔗 https://github.com/masutaka/compare_linker/actions/runs/10349442581/job/28644229198

> An error occurred while loading ./spec/lib/compare_linker/formatter/markdown_spec.rb.
> Failure/Error: require 'factory_bot'
>
> NameError:
>   uninitialized constant #<Class:ActiveSupport::Delegation>::Inflector
> \# ./vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.0/lib/active_support/delegation.rb:47:in \`generate'
> \# ./vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.0/lib/active_support/core_ext/module/delegation.rb:161:in \`delegate'
> \# ./vendor/bundle/ruby/3.3.0/gems/factory_bot-6.4.6/lib/factory_bot/definition_hierarchy.rb:3:in \`<class:DefinitionHierarchy>'
> \# ./vendor/bundle/ruby/3.3.0/gems/factory_bot-6.4.6/lib/factory_bot/definition_hierarchy.rb:2:in \`<module:FactoryBot>'
> \# ./vendor/bundle/ruby/3.3.0/gems/factory_bot-6.4.6/lib/factory_bot/definition_hierarchy.rb:1:in \`<top (required)>'
> \# ./vendor/bundle/ruby/3.3.0/gems/factory_bot-6.4.6/lib/factory_bot.rb:8:in \`<top (required)>'
> \# ./spec/spec_helper.rb:2:in \`<top (required)>'
> \# ./spec/lib/compare_linker/formatter/markdown_spec.rb:1:in \`<top (required)>'

But it does not reproduce in the local environment.
