### PR TITLE
Add contributors badge using contrib.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/masutaka/compare_linker. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
+## Contributors
+
+<a href="https://github.com/masutaka/compare_linker/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=masutaka/compare_linker" />
+</a>
+
+*Made with [contrib.rocks](https://contrib.rocks).*
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
Add contributors badge using https://contrib.rocks/.
I learned about it through https://github.com/Permify/permify.