### PR TITLE
Add dependency with ostruct

### DIFF
--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64"
   spec.add_dependency "httpclient"
   spec.add_dependency "octokit"
+  spec.add_dependency "ostruct"
 
   spec.add_development_dependency "activesupport", ">= 5.0.0", "< 7.2.0" # temporary pinned. See https://github.com/masutaka/compare_linker/pull/50
   spec.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
:link: https://github.com/masutaka/circleci-bundle-update-pr/pull/189#issuecomment-2386242110

> /home/circleci/repo/vendor/bundle/ruby/3.3.0/gems/compare_linker-1.4.7/lib/compare_linker.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add ostruct to your Gemfile or gemspec to silence this warning.