### PR TITLE
Remove workaround to factory_bot and activesupport dependencies

### DIFF
--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit"
   spec.add_dependency "ostruct"
 
-  spec.add_development_dependency "activesupport", ">= 5.0.0", "< 7.2.0" # temporary pinned. See https://github.com/masutaka/compare_linker/pull/50
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This PR removes the workaround added by https://github.com/masutaka/compare_linker/pull/50 .