### PR TITLE
Use rubygems.org if `homepage_uri` cannot be resolved

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -28,7 +28,7 @@ class CompareLinker
         @homepage_uri = gem_info["homepage_uri"]
       end
 
-    rescue HTTPClient::BadResponseError
+    rescue HTTPClient::BadResponseError, Socket::ResolutionError
       @homepage_uri = "https://rubygems.org/gems/#{gem_name}"
     end
 

--- a/spec/lib/compare_linker/github_link_finder_spec.rb
+++ b/spec/lib/compare_linker/github_link_finder_spec.rb
@@ -68,5 +68,17 @@ describe CompareLinker::GithubLinkFinder do
         expect(subject.homepage_uri).to eq "http://jashkenas.github.com/coffee-script/"
       end
     end
+
+    context "if homepage_uri cannot be resolved" do
+      before do
+        exception = Socket::ResolutionError.new "getaddrinfo(3):..."
+        allow(HTTPClient).to receive(:get_content).and_raise exception
+      end
+
+      it "extracts homepage_uri" do
+        subject.find("not_resolved")
+        expect(subject.homepage_uri).to eq "https://rubygems.org/gems/not_resolved"
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello!

I have been using the [compare_linker gem](https://gitlab.com/sue445/gitlabci-bundle-update-mr/) to check for gem updates. Recently, however, an update was made to a gem whose `homepage_uri` listed in the gemspec could not be resolved, causing an error when compare_linker attempted to retrieve the differences.
(Here is a real example: https://github.com/davetron5000/gli/pull/338)

I am unsure whether this gem should handle such cases, but I would appreciate it if you could consider a possible revision.

Thank you for reading this.