### PR TITLE
Fix uninitialized constant error in ruby-3.2 and less for PR #66

### DIFF
--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -28,7 +28,7 @@ class CompareLinker
         @homepage_uri = gem_info["homepage_uri"]
       end
 
-    rescue HTTPClient::BadResponseError, Socket::ResolutionError
+    rescue HTTPClient::BadResponseError, resolution_error_class
       @homepage_uri = "https://rubygems.org/gems/#{gem_name}"
     end
 
@@ -59,6 +59,11 @@ class CompareLinker
       return location if location =~ /\Ahttp/
       # RFC2394 violation?
       "#{uri.scheme}://#{uri.host}#{location}"
+    end
+
+    def resolution_error_class
+      # Socket::ResolutionError is defined from ruby-3.3
+      defined?(Socket::ResolutionError) ? Socket::ResolutionError : SocketError
     end
   end
 end

--- a/lib/compare_linker/github_link_finder.rb
+++ b/lib/compare_linker/github_link_finder.rb
@@ -28,7 +28,7 @@ class CompareLinker
         @homepage_uri = gem_info["homepage_uri"]
       end
 
-    rescue HTTPClient::BadResponseError
+    rescue HTTPClient::BadResponseError, Socket::ResolutionError
       @homepage_uri = "https://rubygems.org/gems/#{gem_name}"
     end
 

--- a/spec/lib/compare_linker/github_link_finder_spec.rb
+++ b/spec/lib/compare_linker/github_link_finder_spec.rb
@@ -71,7 +71,9 @@ describe CompareLinker::GithubLinkFinder do
 
     context "if homepage_uri cannot be resolved" do
       before do
-        exception = Socket::ResolutionError.new "getaddrinfo(3):..."
+        # Socket::ResolutionError is defined from ruby-3.3
+        error_class = defined?(Socket::ResolutionError) ? Socket::ResolutionError : SocketError
+        exception = error_class.new "getaddrinfo(3):..."
         allow(HTTPClient).to receive(:get_content).and_raise exception
       end
 

--- a/spec/lib/compare_linker/github_link_finder_spec.rb
+++ b/spec/lib/compare_linker/github_link_finder_spec.rb
@@ -68,5 +68,17 @@ describe CompareLinker::GithubLinkFinder do
         expect(subject.homepage_uri).to eq "http://jashkenas.github.com/coffee-script/"
       end
     end
+
+    context "if homepage_uri cannot be resolved" do
+      before do
+        exception = Socket::ResolutionError.new "getaddrinfo(3):..."
+        allow(HTTPClient).to receive(:get_content).and_raise exception
+      end
+
+      it "extracts homepage_uri" do
+        subject.find("not_resolved")
+        expect(subject.homepage_uri).to eq "https://rubygems.org/gems/not_resolved"
+      end
+    end
   end
 end


### PR DESCRIPTION
It resolves the CI errors of PR https://github.com/masutaka/compare_linker/pull/66.