### PR TITLE
Fix the warning of reviewdog/action-actionlint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Run actionlint
       uses: reviewdog/action-actionlint@abd537417cf4991e1ba8e21a67b1119f4f53b8e0 # v1.64.1
       with:
-        fail_on_error: true
+        fail_level: error
         filter_mode: nofilter
         level: error
         reporter: github-pr-review


### PR DESCRIPTION
<img width="719" alt="warning" src="https://github.com/user-attachments/assets/43a34742-1d12-4143-80f2-6e34c4c56ef0" />

See https://github.com/reviewdog/action-actionlint
