### PR TITLE
Remove workaround for httpclient gem

### DIFF
--- a/compare_linker.gemspec
+++ b/compare_linker.gemspec
@@ -18,9 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  # [Workaround] Remove it httpclient containing https://github.com/nahi/httpclient/pull/455 when released (v2.8.3 higher).
-  spec.add_dependency "mutex_m" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
-
   spec.add_dependency "base64"
   spec.add_dependency "httpclient"
   spec.add_dependency "octokit"


### PR DESCRIPTION
* resolves https://github.com/masutaka/compare_linker/issues/69

It reverts commit 674069d7c9c1a5b677a938d0e940dcaf624fa188.
