### PR TITLE
Add pinact config and apply action pinning policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
       - name: Run actionlint
         uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
         with:
@@ -44,7 +44,7 @@ jobs:
           - "3.3"
           - "3.4"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+
+version: 3
+
+ignore_actions:
+  # Official Actions managed by GitHub are considered low risk for supply chain attacks,
+  # so SHA hash pinning is not applied.
+  # Use major version tags (v\d+) and rely on dependabot for automatic version updates.
+  - name: actions/.*
+    ref: v\d+
+  - name: github/.*
+    ref: v\d+
+  # masutaka/* are actions managed by the repo owner, so main branch references are allowed.
+  - name: masutaka/.*
+    ref: main


### PR DESCRIPTION
## Summary

- Add `.pinact.yaml` to define the pinact action pinning policy
- Exempt `actions/*` and `github/*` from SHA pinning since they are low risk for supply chain attacks; use major version tags instead
- Allow `main` branch references for `masutaka/*` (owner-managed actions)
- Apply the policy to `test.yml`: revert `actions/checkout` from SHA hash to `@v6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions checkout step to use the v6 release tag
  * Introduced configuration file to manage GitHub Actions version constraints and dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->